### PR TITLE
Added missing pcl_ros dependency in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -62,6 +62,7 @@
   <build_depend>image_view</build_depend>
   <build_depend>tf2_geometry_msgs</build_depend>
   <build_depend>compressed_depth_image_transport</build_depend>
+  <build_depend>pcl_ros</build_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>cv_bridge</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
@@ -74,6 +75,7 @@
   <build_export_depend>image_view</build_export_depend>
   <build_export_depend>tf2_geometry_msgs</build_export_depend>
   <build_export_depend>compressed_depth_image_transport</build_export_depend>
+  <build_export_depend>pcl_ros</build_export_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>cv_bridge</exec_depend>
   <exec_depend>std_msgs</exec_depend>
@@ -87,6 +89,7 @@
   <exec_depend>image_view</exec_depend>
   <exec_depend>tf2_geometry_msgs</exec_depend>
   <exec_depend>compressed_depth_image_transport</exec_depend>
+  <exec_depend>pcl_ros</exec_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
Hi,

I got below error while building the source:

> -- Using these message generators: gencpp;geneus;genlisp;gennodejs;genpy
> -- Could NOT find pcl_ros (missing: pcl_ros_DIR)
> -- Could not find the required component 'pcl_ros'. The following CMake error indicates that you either need to install the package with the same name or change your environment so that it can be found.
> CMake Error at /opt/ros/noetic/share/catkin/cmake/catkinConfig.cmake:83 (find_package):
>   Could not find a package configuration file provided by "pcl_ros" with any
>   of the following names:
> 
>     pcl_rosConfig.cmake
>     pcl_ros-config.cmake
> 
>   Add the installation prefix of "pcl_ros" to CMAKE_PREFIX_PATH or set
>   "pcl_ros_DIR" to a directory containing one of the above files.  If
>   "pcl_ros" provides a separate development package or SDK, be sure it has
>   been installed.
> Call Stack (most recent call first):
>   adi_3dtof_adtf31xx/CMakeLists.txt:10 (find_package)
> 

-- Configuring incomplete, errors occurred!
Invoking "cmake" failed

We are installing the dependencies using [step 2](https://github.com/analogdevicesinc/adi_3dtof_adtf31xx?tab=readme-ov-file#steps-to-run-adi_3dtof_adtf31xx_node-node) but it is not installing `pcl_ros` as it is not mentioned in the depend list.

This PR updates the same.
